### PR TITLE
Introduce proper support for Folia

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ WelcomeMat is available on Modrinth! Click the button below to download:
 
 WelcomeMat is compatible with Minecraft versions 1.13 through 1.21.10 and is fully tested on Bukkit/Spigot, Paper, Purpur, and Folia (regionized multithreading). The Folia build uses region-aware schedulers so the same jar runs safely on both single-threaded and regionized servers.
 
+### 🚀 What's New in v1.3.1
+- **Folia-safe animations:** Join effects now use the latest Folia entity schedulers, keeping animations responsive without tripping the watchdog on 1.21.8+.
+- **Smarter fallbacks:** If Folia ever exposes a new scheduler signature, the plugin logs the discovery and skips unsafe fallbacks instead of touching Bukkit's global scheduler.
+- **Automatic version metadata:** `plugin.yml` now receives the Gradle project version at build time, so downloads are always correctly labeled.
+
 ## ✨ Features
 
 ### Core Features


### PR DESCRIPTION
## Summary
WelcomeMat compatibility with Folia is fixed in v1.3.1 and up

---
## Changes
- make the Folia scheduler adapter resilient to the new `EntityScheduler#runAtFixedRate` overloads and clamp task delays so join animations stay Folia-safe #1 
- removed unsupported Bukkit-scheduler fallback on Folia; now logs any future unknown signatures for easier debugging
- bump version to 1.3.1
- auto-expand the plugin.yml version (minor)

## Testing
- .\gradlew.bat build
- Folia 1.21.8 local server (player join + animation smoke test)
- Purpur 1.21.10 local server (player join + animation smoke test)